### PR TITLE
Remove broken links in why camel

### DIFF
--- a/docs/user-manual/modules/faq/pages/why-the-name-camel.adoc
+++ b/docs/user-manual/modules/faq/pages/why-the-name-camel.adoc
@@ -2,8 +2,7 @@
 
 * it stands for Concise Application Message Exchange Language (i.e. the
 Java xref:ROOT:dsl.adoc[DSL] for routing)
-* a Camel can carry http://www.fao.org/sd/EGdirect/EGan0006.htm[4 times
-the load] of other beasts of burden
+* a Camel can carry 4 times the load of other beasts of burden
 * a Camel can travel for great distances without water; similarly a
 Camel does not require bucket loads of XML as you can use a pure Java
 xref:ROOT:dsl.adoc[DSL]
@@ -16,8 +15,7 @@ http://en.wikipedia.org/wiki/Hybrid_animals#Equid_Hybrids[evolutionary
 dead end]
 * a Camel looks really funny when it's running, like most of the team :smile:
 * a Camel is a horse designed by committee :smile:
-* a http://www.groapacuprosti.com/2010/09/camel-in-action.html[Camel in
-Action] is really funny
+* a Camel in Action is really funny
 
 We generated some really cheesy tag lines like:
 


### PR DESCRIPTION
## Motivation

Some links point to web pages that don't exist anymore

## Modifications

* Removed the broken links. 

**NB:** The other possibility could have been to rely on web.archive.org like for example (https://web.archive.org/web/20131108024540/http://www.fao.org/sd/EGdirect/EGan0006.htm) but I felt that it was not really needed in this context WDYT?
